### PR TITLE
fix: Fix type of cookie-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@gravity-ui/nodekit": "^0.2.0",
         "body-parser": "^1.20.1",
+        "cookie-parser": "1.4.6",
         "express": "^4.18.2",
         "uuid": "^9.0.0"
       },
@@ -23,7 +24,6 @@
         "@types/jest": "^29.2.3",
         "@types/node": "^18.11.9",
         "@types/uuid": "^9.0.0",
-        "cookie-parser": "^1.4.6",
         "eslint": "^8.28.0",
         "husky": "^8.0.2",
         "jest": "^29.3.1",
@@ -2761,7 +2761,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2770,7 +2769,6 @@
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
       "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "dev": true,
       "dependencies": {
         "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
@@ -10685,14 +10683,12 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-parser": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
       "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "dev": true,
       "requires": {
         "cookie": "0.4.1",
         "cookie-signature": "1.0.6"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
     "@types/uuid": "^9.0.0",
-    "cookie-parser": "^1.4.6",
     "eslint": "^8.28.0",
     "husky": "^8.0.2",
     "jest": "^29.3.1",
@@ -37,6 +36,7 @@
   "dependencies": {
     "@gravity-ui/nodekit": "^0.2.0",
     "body-parser": "^1.20.1",
+    "cookie-parser": "1.4.6",
     "express": "^4.18.2",
     "uuid": "^9.0.0"
   }


### PR DESCRIPTION
In the previous version of the project, when using the `@gravity-ui/expresskit`, it was necessary to explicitly import cookie-parser, even though the user code did not depend on it. This introduced unnecessary complexity and confusion. I have moved the cookie-parser dependency from the devDependencies section to the production dependencies section.