### PR TITLE
feat: add express cookie secret as array for rotation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ declare module 'express' {
 declare module '@gravity-ui/nodekit' {
     interface AppConfig {
         expressTrustProxyNumber?: number | boolean;
-        expressCookieSecret?: string;
+        expressCookieSecret?: string | string[];
         expressRequestIdHeaderName?: string;
 
         expressDisableBodyParserJSON?: boolean;


### PR DESCRIPTION
Add support expressCookieSecret as array of strings for secret rotation support

Description at cookie-parser package doc

https://www.npmjs.com/package/cookie-parser

```
secret a string or array used for signing cookies. 
This is optional and if not specified, will not parse signed cookies. 
If a string is provided, this is used as the secret. 
If an array is provided, an attempt will be made to unsign the cookie with each secret in order.
```