### PR TITLE
feat: add an option for omitting req id in log message

### DIFF
--- a/src/base-middleware.ts
+++ b/src/base-middleware.ts
@@ -26,7 +26,7 @@ export function setupBaseMiddleware(ctx: AppContext, expressApp: Express) {
 
             req.originalContext = req.ctx = ctx.create(`Express ${req.method}`, {
                 parentSpanContext,
-                loggerPostfix: `[${requestId}]`,
+                loggerPostfix: ctx.config.appLoggingOmitIdInMessages ? '' : `[${requestId}]`,
                 spanKind: 1, // SERVER
             });
             req.ctx.set(REQUEST_ID_PARAM_NAME, requestId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ declare module '@gravity-ui/nodekit' {
 
         appTelemetryChEnableSelfStats?: boolean;
 
+        appLoggingOmitIdInMessages?: boolean;
+
         expressCspEnable?: boolean;
         expressCspPresets?:
             | CSPPreset


### PR DESCRIPTION
New config option is added: `appLoggingOmitIdInMessages`. It would allow to omit request id postfix in log messages.

In the future we'll probably remove req ids from log messages string entirely, since they make it hard to use observability features that rank log messages by frequency.

[Some internal context](https://st.yandex-team.ru/DATAUI-3270).