### PR TITLE
fix: resolve AppContext memory leak for direct app.express handlers

### DIFF
--- a/src/base-middleware.ts
+++ b/src/base-middleware.ts
@@ -93,6 +93,14 @@ export function setupBaseMiddleware(ctx: AppContext, expressApp: Express) {
                 req.originalContext.setTag('http.status_code', statusCode);
             });
 
+            res.on('close', () => {
+                setImmediate(() => {
+                    if (!req.originalContext.abortSignal?.aborted) {
+                        req.originalContext.end();
+                    }
+                });
+            });
+
             next();
             return;
         } catch (error) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -148,12 +148,6 @@ export function setupRoutes(ctx: AppContext, expressApp: Express, routes: AppRou
                 }
             });
 
-            res.on('close', () => {
-                setImmediate(() => {
-                    req.originalContext.end();
-                });
-            });
-
             next();
         };
 

--- a/src/tests/context-lifecycle.test.ts
+++ b/src/tests/context-lifecycle.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable callback-return */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import request from 'supertest';
+import {getEventListeners} from 'node:events';
+
 import {AppContext, NodeKit} from '@gravity-ui/nodekit';
 
 import {ExpressKit, NextFunction, Request, Response} from '..';
@@ -396,6 +398,36 @@ describe('Context Lifecycle', () => {
                 .agent(app.express)
                 .get('/test')
                 .catch(() => {});
+        });
+    });
+
+    describe('Bare app.express handler cleanup', () => {
+        it('should clean up context for handlers registered directly on app.express', async () => {
+            const nodekit = new NodeKit();
+            const app = new ExpressKit(nodekit, {});
+
+            const contexts: AppContext[] = [];
+
+            app.express.get('/bare', (req, res) => {
+                contexts.push((req as Request).originalContext);
+                res.json({ok: true});
+            });
+
+            const baseline = getEventListeners(nodekit.ctx.abortSignal, 'abort').length;
+            const N = 20;
+
+            const agent = request.agent(app.express);
+            for (let i = 0; i < N; i++) {
+                await agent.get('/bare');
+                // Wait for setImmediate in 'close' event handler to execute context cleanup
+                await new Promise((resolve) => setImmediate(resolve));
+            }
+
+            expect(getEventListeners(nodekit.ctx.abortSignal, 'abort').length).toBe(baseline);
+            expect(contexts.length).toBe(N);
+            contexts.forEach((ctx) => {
+                expect(ctx.abortSignal?.aborted).toBe(true);
+            });
         });
     });
 });


### PR DESCRIPTION
## Problem
Currently, the per-request `AppContext` cleanup (`res.on('close', () => req.originalContext.end())`) only happens inside `routeInfoMiddleware`. This middleware is only attached per-route during `setupRoutes`. 

If consumers register handlers directly on `app.express` (e.g., `app.express.get('/healthz', handler)`, they bypass `setupRoutes`. As a result, every request to these bare routes permanently leaks:
- An `'abort'` event listener on the long-lived root `nodekit.ctx.abortSignal`
- An `AppContext` instance
- An OTel `Span`

## Solution
This PR moves the per-request `AppContext` cleanup hook from the per-route `routeInfoMiddleware` into the global `setupBaseMiddleware`. 

Because `setupBaseMiddleware` is the same place the context is originally created, the cleanup will now reliably run for every request that hits the Express app, regardless of how the handler was registered. 
